### PR TITLE
Optionally do not delete unassociated A records

### DIFF
--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -29,6 +29,7 @@ var (
 	pushgatewayIntervalSeconds int
 	pushgatewayLabels          cmd.KeyValues
 	awsAPIRetries              int
+	r53DelAssocOnly            bool
 )
 
 func init() {
@@ -67,6 +68,8 @@ func init() {
 		"A label=value pair to attach to metrics pushed to prometheus. Specify multiple times for multiple labels.")
 	flag.IntVar(&awsAPIRetries, "aws-api-retries", defaultAwsAPIRetries,
 		"Number of times a request to the AWS API is retried.")
+	flag.BoolVar(&r53DelAssocOnly, "del-assoc-only", false,
+		"Only delete Route53 entries associated with ELBs/ALBs configured with this controller.")
 }
 
 func main() {
@@ -81,7 +84,7 @@ func main() {
 		log.Fatal("Unable to create k8s client: ", err)
 	}
 
-	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries)
+	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries, r53DelAssocOnly)
 
 	controller := controller.New(controller.Config{
 		KubernetesClient: client,


### PR DESCRIPTION
- Add a switch to prevent the deletion of unassociated A records
- If this switch is passed, only records which are directly associated
with a LB matching the selection criteria of this controller will be
deleted when no matching ingress is found.